### PR TITLE
Attempt to handle . in names

### DIFF
--- a/xsd2go.xsl
+++ b/xsd2go.xsl
@@ -769,7 +769,7 @@
     <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
     <xsl:for-each select="str:tokenize($normName, '_- ')">
       <xsl:value-of select="translate(substring(.,1,1),$lowercase,$uppercase)"/>
-      <xsl:value-of select="substring(.,2)"/>
+      <xsl:value-of select="translate(substring(.,2), '.', '_')"/>
     </xsl:for-each>
   </xsl:template>
 


### PR DESCRIPTION
Example of this occurs in versionDefinition in sruResponse.xsd https://docs.oasis-open.org/search-ws/searchRetrieve/v1.0/os/schemas/